### PR TITLE
Improve doc of "Choosing from a populated table"

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -52,8 +52,9 @@ simply use a :class:`factory.Iterator` on the chosen queryset:
 
         language = factory.Iterator(models.Language.objects.all())
 
-Here, ``models.Language.objects.all()`` won't be evaluated until the
-first call to ``UserFactory``; thus avoiding DB queries at import time.
+Here, ``models.Language.objects.all()`` is a QuerySet and will only hit the database
+when factory_boy will start iterating on it, i.e on the first call to ``UserFactory``;
+thus avoiding DB queries at import time.
 
 
 Reverse dependencies (reverse ForeignKey)


### PR DESCRIPTION
models.Language.objects.all() does gets evaluated at runtime but that returns a QuerySet, django only hit the database when we start iterating in the queryset.
Previous documentation was a bit misleading.

I would find more intuitive to recommend to use `language = factory.Iterator(models.Language.objects.all)` but I havn't changed that here, let me know if you prefer that I change it that way